### PR TITLE
Make verification clean again

### DIFF
--- a/src/bot/cogs/verification/verification_on_join.py
+++ b/src/bot/cogs/verification/verification_on_join.py
@@ -72,27 +72,22 @@ class LoggingVerification(commands.Cog):
         """
         if message.channel.id == int(self.verification_channel):
             if not message.author.bot:
-                if f"{os.getenv('PREFIX')}verify" == message.content:
-                    # user is doing it right
+                if f"{os.getenv('PREFIX')}verify" == message.content:  # keep it exact
+                    # user is doing it right, and the verification_dropdown is triggered
                     await sleep(3)
-                    await message.delete()
+                    await message.delete()  # cleanup correct verification calls
                     return
+                else:  # this covers any other message in the channel.
+                    await message.delete()  # delete the user's incorrect message
+                    bot_message = await message.channel.send(
+                        f"You need to use the **{os.getenv('PREFIX')}verify** command.")
 
-                channel_message = await message.channel.send(
-                    f"You need to use the **{os.getenv('PREFIX')}verify** command.")
+                    logs_channel = await self.bot.fetch_channel(self.verification_log)
+                    await logs_channel.send(
+                        f"{message.author} is failing at life in {self.bot.get_channel(self.verification_log).mention}")
 
-                await message.delete()
-                logs_channel = await self.bot.fetch_channel(self.verification_log)
-                await logs_channel.send(
-                    f"{message.author} is failing at life in {self.bot.get_channel(self.verification_log).mention}")
-
-                if channel_message:
-                    await sleep(10)  # wait 10 seconds, and then we delete the message in the channel
-
-                    async for msg in message.channel.history(limit=5):
-                        if msg.author.bot:
-                            await msg.delete()
-                            break  # only delete 1
+                    await sleep(8)
+                    bot_message.delete()  # remove the message to correct people after 8? seconds
 
 
 async def setup(bot: commands.Bot) -> None:


### PR DESCRIPTION
Updated verification channel logic to correctly remove messages, alert the user of the correct way to verify, and clean up after itself.

solves #29