### PR TITLE
API logging cleanup and new feature

### DIFF
--- a/src/api/core/db_helper.py
+++ b/src/api/core/db_helper.py
@@ -46,6 +46,16 @@ class DB:
             logger.error(f"Error fetching logging: {err}")
             return {"status": "error", "message": str(err)}
 
+    def get_log_setting_by_name(self, name):
+        logger.debug("API attempting to contact DB for get_log_setting_by_name...")
+        try:
+            self.cursor.execute("SELECT * FROM logging WHERE name = %s", (name,))
+            result = self.cursor.fetchone()
+            return {"status": "ok", "logging": result}
+        except OperationalError as err:
+            logger.error(f"Error fetching logging: {err}")
+            return {"status": "error", "message": str(err)}
+
     def get_log_settings(self):
         logger.debug("API attempting to contact DB for get_log_settings...")
         try:
@@ -75,6 +85,15 @@ class DB:
             logger.error(f"Error updating log setting: {err}")
             return {"status": "error", "message": str(err)}
 
+    def update_logging_by_name(self, name, value):
+        logger.debug(f"API attempting to contact DB for update_logging with log name:{name} - Value:{value}")
+        try:
+            self.cursor.execute("UPDATE logging SET value = %s WHERE name = %s", (value, name))
+            return {"status": "ok", "message": "Log setting updated successfully"}
+        except OperationalError as err:
+            logger.error(f"Error updating log setting: {err}")
+            return {"status": "error", "message": str(err)}
+
     def add_log_setting(self, name, value):
         logger.debug(f"API attempting to contact DB for add_log with name:{name} - Value:{value}")
         try:
@@ -91,6 +110,15 @@ class DB:
             return {"status": "ok", "message": f"Log with ID {log_id} deleted successfully"}
         except OperationalError as err:
             logger.error(f"Error deleting log setting: {err}")
+            return {"status": "error", "message": str(err)}
+
+    def delete_log_setting_by_name(self, name):
+        logger.debug(f"API attempting to contact DB for delete_log by name: {name}")
+        try:
+            self.cursor.execute("DELETE FROM logging WHERE name = %s", (name,))
+            return {"status": "ok", "message": f"Log with name '{name}' deleted successfully"}
+        except OperationalError as err:
+            logger.error(f"Error deleting log setting by name: {err}")
             return {"status": "error", "message": str(err)}
 
     ##################

--- a/src/api/routes/logging.py
+++ b/src/api/routes/logging.py
@@ -8,67 +8,87 @@ logger = logging.getLogger(__name__)
 # Define a Blueprint
 logs = Blueprint('logging', __name__)
 
+ALLOWED_LOG_NAMES = ["chat", "moderation", "user", "join", "verification"]
 
 @logs.route('/logging', methods=['GET'])
-@logs.route('/logging/<int:log_id>', methods=['GET'])
-def get_log_setting(log_id=None):
+def get_log_setting():
     """
     Retrieve logging settings from the database.
-
-    :param log_id: Optional integer ID of a specific setting
-    :return: JSON response with log setting
+    Can take:
+      - no params: returns all
+      - integer param: returns one by id
+      - string param: returns by name if in PREDEFINED_LOG_NAMES
     """
-    if log_id is None:
-        # Retrieve all log settings
-        result = eos.db.get_log_settings()
+    log_id = request.args.get('id')
+    log_name = request.args.get('name')
+
+    if log_id is not None:
+        try:
+            result = eos.db.get_log_setting(int(log_id))
+            return jsonify(result), 200
+        except ValueError:
+            return jsonify({"status": "error", "message": "id must be an integer"}), 400
+    elif log_name is not None:
+        if log_name in ALLOWED_LOG_NAMES:
+            result = eos.db.get_log_setting_by_name(log_name) # TODO: Define me
+            return jsonify(result), 200
+        else:
+            return jsonify({"status": "error", "message": "Invalid log name"}), 400
+
     else:
-        # Retrieve a single setting
-        result = eos.db.get_log_setting(log_id)
+        result = eos.db.get_log_settings()
+        return jsonify(result), 200
 
-    return jsonify(result, 200)
-
-# @settings.route('/log_settings', methods=['GET'])
-# def get_log_settings():
-#     """
-#     Retrieve log settings from the database.
-#
-#     :return: JSON response with settings
-#     """
-#     result = eos.db.get_log_settings()
-#
-#     return jsonify(result, 200)
-
-@logs.route('/logging/<log_id>', methods=['PUT'])
-def update_log_setting(log_id):
+@logs.route('/logging/<log_identifier>', methods=['PUT'])
+def update_log_setting(log_identifier):
     """
-    Update an existing setting in the database.
+    Update an existing log setting by ID (int) or predefined name (string).
     """
-    if request.method == 'PUT':
-        data = request.json
-        result = eos.db.update_logging(int(log_id), data['value'])
-        return jsonify(result, 200)
+    data = request.json
+    value = data.get('value')
+    if value is None:
+        return jsonify({"status": "error", "message": "Missing required field: value"}), 400
 
-    return jsonify({'message': 'improper request method'}, 405)
+    try:
+        result = eos.db.update_logging(int(log_identifier), value)
+        return jsonify(result), 200
+    except ValueError:
+        if log_identifier in ALLOWED_LOG_NAMES:
+            result = eos.db.update_logging_by_name(log_identifier, value)
+            return jsonify(result), 200
+        else:
+            return jsonify({"status": "error", "message": "Invalid log identifier"}), 400
 
 @logs.route('/logging', methods=['POST'])
 def add_log_setting():
     """
-    Add a new setting to the database.
+    Add a new setting to the database but only if the name is in the predefined allowed set.
     """
     if request.method == 'POST':
         data = request.json
-        result = eos.db.add_log_setting(data['name'], data['value'])
-        return jsonify(result, 201)
+        name = data.get('name')
+        value = data.get('value')
+        if not name or not value:
+            return jsonify({"status": "error", "message": "Missing 'name' or 'value'"}), 400
+        if name not in ALLOWED_LOG_NAMES:
+            return jsonify({"status": "error", "message": f"Invalid log name: {name}"}), 400
 
-    return jsonify({'message': 'improper request method'}, 405)
+        result = eos.db.add_log_setting(name, value)
+        return jsonify(result), 201
 
-@logs.route('/logging/<int:log_id>', methods=['DELETE'])
-def delete_log_setting(log_id):
+    return jsonify({'message': 'improper request method'}), 405
+
+@logs.route('/logging/<log_identifier>', methods=['DELETE'])
+def delete_log_setting(log_identifier):
     """
-    Delete a specific setting from the database.
+    Delete a log setting by ID (int) or predefined name (string).
     """
-    if request.method == 'DELETE':
-        result = eos.db.delete_log_setting(log_id)
-        return jsonify(result, 200)
-
-    return jsonify({'message': 'improper request method'}, 405)
+    try:
+        result = eos.db.delete_log_setting(int(log_identifier))
+        return jsonify(result), 200
+    except ValueError:
+        if log_identifier in ALLOWED_LOG_NAMES:
+            result = eos.db.delete_log_setting_by_name(log_identifier)
+            return jsonify(result), 200
+        else:
+            return jsonify({"status": "error", "message": "Invalid log identifier"}), 400

--- a/src/api/routes/logging.py
+++ b/src/api/routes/logging.py
@@ -8,7 +8,15 @@ logger = logging.getLogger(__name__)
 # Define a Blueprint
 logs = Blueprint('logging', __name__)
 
-ALLOWED_LOG_NAMES = ["chat", "moderation", "user", "join", "verification"]
+ALLOWED_LOG_NAMES = [
+    'Verification Log',
+    'Join Log',
+    'Chat Log',
+    'User Log',
+    'Mod Log',
+    'Server Log',
+    'Error Log'
+]
 
 @logs.route('/logging', methods=['GET'])
 def get_log_setting():


### PR DESCRIPTION
This PR updates the logging API to allow identifying log settings not only by numeric ID but also by a predefined set of exact string names that match the entries in the database (e.g., "Verification Log", "Join Log", etc.).

Key Changes:
- GET /logging endpoint can now accept either no parameter (returns all), an integer id, or a predefined string name to fetch a specific log setting.

- PUT /logging/<identifier> endpoint accepts either an integer ID or a predefined name to update a log setting.

- POST /logging endpoint enforces that new log settings can only be added with valid predefined names (matching DB names).

- DELETE /logging/<identifier> endpoint supports deletion by either ID or predefined log name.

- Updated DB helper with queries supporting both ID and exact name lookups for logging settings.

- Allowed log names set updated to precisely match log names defined in the database initialization script, including spaces and capitalization.