### PR TITLE
Disckit Integration for Error & Status Handling

### DIFF
--- a/src/bot/requirements-bot.txt
+++ b/src/bot/requirements-bot.txt
@@ -5,6 +5,7 @@ blinker==1.9.0
 certifi==2025.4.26
 charset-normalizer==3.4.2
 click==8.2.0
+disckit==1.1.3
 discord.py==2.5.2
 frozenlist==1.5.0
 idna==3.10


### PR DESCRIPTION
This PR integrates the [disckit](https://github.com/disutils/disckit) library to the bot.

The main features added to it are-
- Error Handling
- Status Handling

The disckit library is mainly built around application commands only of discord.py, hence the error handler may not be able to catch errors related to hybrid or prefix commands (maybe I'll fix that in the future).

The status handling is pretty straight-forward and simple. I've left around comments to hopefully explain better what the library is doing.

There is also a help command plugin in the library, but it bugs out since there are prefix commands also (it only works with pure app-commands bots).

Other than that there are also some minor things you can configure like the error embed colour (`disckit.UtilConfig.ERROR_COLOR`), title emoji (`disckit.UtilConfig.ERROR_EMOJI`), footer (`disckit.UtilConfig.FOOTER_TEXT`), etc.

You can let me know if you need any clarification.