### PR TITLE
Changed wording for update_points in bot/cogs/admin/points.py

### DIFF
--- a/src/bot/cogs/admin/points.py
+++ b/src/bot/cogs/admin/points.py
@@ -91,7 +91,7 @@ class Points(commands.Cog):
             await ctx.reply(
                 embed=embed_info(
                     ""
-                    , f"{amount} points {'removed from' if amount.startswith('-') else 'added to'} to {user.display_name}"
+                    , f"{amount.lstrip('-')} points {'removed from' if amount.startswith('-') else 'added to'} {user.display_name}"
                     , discord.Color.green() if not amount.startswith('-') else discord.Color.red()
                 )
             )

--- a/src/bot/cogs/admin/points.py
+++ b/src/bot/cogs/admin/points.py
@@ -91,7 +91,7 @@ class Points(commands.Cog):
             await ctx.reply(
                 embed=embed_info(
                     ""
-                    , f"{amount.lstrip('-')} points {'removed from' if amount.startswith('-') else 'added to'} {user.display_name}"
+                    , f"{amount.lstrip('-+')} points {'removed from' if amount.startswith('-') else 'added to'} {user.display_name}"
                     , discord.Color.green() if not amount.startswith('-') else discord.Color.red()
                 )
             )


### PR DESCRIPTION
The update points display said "n points removed from to <user>" or "n points added to to <user>". This PR removes the extra "to" from the message. 

It also was displaying a negative number of points that were "removed".  This PR removes the negative sign from displaying.