### PR TITLE
fix datetime error that was breaking master

### DIFF
--- a/src/bot/cogs/admin/settings.py
+++ b/src/bot/cogs/admin/settings.py
@@ -45,7 +45,7 @@ class Settings(commands.Cog):
        embed = discord.Embed(title="-- Settings --",
                       description="Here, you can see the current settings for the server.",
                       colour=0x000000,
-                      timestamp=datetime.now())
+                      timestamp=datetime.datetime.now())
 
        for setting in server_settings[0]["setting"]:
            value = f"<#{setting[2]}>" if setting[2] != '0' else 'Off'

--- a/src/bot/cogs/moderation/admin_automod_spam_messages.py
+++ b/src/bot/cogs/moderation/admin_automod_spam_messages.py
@@ -102,7 +102,7 @@ class ModerationSpamMessages(commands.Cog):
                 f"|{attachment.filename}|{attachment.size}|{attachment.content_type}".encode()
             ).hexdigest()
 
-        now = datetime.now().astimezone()
+        now = datetime.datetime.now(datetime.timezone.utc)
         record = self.records.get(
             author_id,
             {

--- a/src/bot/cogs/moderation/admin_automod_spam_messages.py
+++ b/src/bot/cogs/moderation/admin_automod_spam_messages.py
@@ -233,7 +233,7 @@ class ModerationSpamMessages(commands.Cog):
                 f"You already posted this in {first_channel.mention}"
             )
         finally:
-            fifteen_seconds = datetime.now().astimezone() + datetime.timedelta(seconds=15)
+            fifteen_seconds = datetime.datetime.now().astimezone() + datetime.timedelta(seconds=15)
             await message.author.timeout(
                 fifteen_seconds, reason="Sending the same message multiple times."
             )
@@ -257,7 +257,7 @@ class ModerationSpamMessages(commands.Cog):
 
             quarantine_channel = self.bot.api.get_one_setting("2")[0]["setting"][2]
             quarantine_channel = await self.bot.fetch_channel(quarantine_channel)
-            thirty_seconds = datetime.now().astimezone() + datetime.timedelta(seconds=30)
+            thirty_seconds = datetime.datetime.now().astimezone() + datetime.timedelta(seconds=30)
 
             await message.author.timeout(
                 thirty_seconds, reason="Sending the same message multiple times."
@@ -280,7 +280,7 @@ class ModerationSpamMessages(commands.Cog):
             self.records[author_id] = {
                 "last_message": None,
                 "occurrence": 0.0,
-                "last_update": datetime.now().astimezone(),
+                "last_update": datetime.datetime.now().astimezone(),
                 "stage": 0,
                 "messages": [],
             }


### PR DESCRIPTION
Error in the master, alert alert alert. We should probably put some time into some kind of build checker. 
```bash
2026-05-15 15:01:14 ERROR    discord.client Ignoring exception in on_message
Traceback (most recent call last):
  File "/usr/local/lib/python3.12/site-packages/discord/client.py", line 481, in _run_event
    await coro(*args, **kwargs)
  File "/bot/cogs/moderation/admin_automod_spam_messages.py", line 105, in on_message
    now = datetime.now().astimezone()
          ^^^^^^^^^^^^
AttributeError: module 'datetime' has no attribute 'now'

```