### PR TITLE
Format leaderboard points with thousands separator

### DIFF
--- a/src/bot/cogs/admin/points.py
+++ b/src/bot/cogs/admin/points.py
@@ -126,7 +126,7 @@ class Points(commands.Cog):
             await ctx.reply(
                 embed=embed_info(
                     "Top 10 Point Earners"
-                    , "\n".join([f"{index + 1}. {user_name} - {points}"
+                    , "\n".join([f"{index + 1}. {user_name} - {points:,}"
                               for index, (user_name, points) in enumerate(data)])
                     , discord.Color.yellow()
                 )


### PR DESCRIPTION
Commas make it easier to read how many points the users have!
E.g., "100000" to "100,000".