### PR TITLE
CI: enforce pre-commit checks on push and PR (#137)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,17 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - uses: pre-commit/action@v3.0.1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,7 +65,7 @@ uv sync
 
 ## pre-commit
 
-We use [pre-commit](https://pre-commit.com) to run formatting, linting and security checks before each commit.
+We use [pre-commit](https://pre-commit.com) to run formatting, linting and security checks before each commit. The same checks run automatically in CI (`.github/workflows/ci.yml`) on every push and pull request to `master`.
 
 Install the hooks once after cloning:
 ```bash

--- a/src/bot/core/api_helper.py
+++ b/src/bot/core/api_helper.py
@@ -32,7 +32,6 @@ class API:
                 results["db_status"] = await response.json()
             return results
 
-
     ##############################
     #           Logging          #
     ##############################


### PR DESCRIPTION
- Adds .github/workflows/ci.yml — runs on every push and PR to master, checks out the code, sets up Python 3.12, and runs pre-commit/action@v3.0.1 which auto-reads .pre-commit-config.yaml
- Updates CONTRIBUTING.md to note that the same pre-commit checks are enforced in CI

Why
Pre-commit hooks only ran locally if a developer had them installed. This closes the gap — violations (ruff lint/format, bandit, YAML/JSON/TOML validity, merge conflict markers, etc.) now correctly fail the CI job rather than landing silently on master.

Notes
- pre-commit/action runs hooks in check-only mode — it does not auto-commit fixes, so formatting violations will fail the job as expected
- No version pinning changes needed; Bandit 1.8.6 and Ruff v0.15.15 are already pinned in .pre-commit-config.yaml

Closes #137