### PR TITLE
fix: replace blocking time.sleep with async asyncio.sleep in quarantine cog

### DIFF
--- a/src/bot/cogs/moderation/admin_quarantine.py
+++ b/src/bot/cogs/moderation/admin_quarantine.py
@@ -2,9 +2,9 @@
 Admin command for kicking a user.
 """
 
+import asyncio
 import datetime
 import logging
-import time
 
 import discord
 from discord import app_commands
@@ -137,7 +137,7 @@ class AdminQuarantine(commands.Cog):
                             if message.author.name == target.name:
                                 await message.delete()
                                 message_counter += 1
-                                time.sleep(0.2)  # Avoiding rate limits.
+                                await asyncio.sleep(0.2)  # Avoiding rate limits.
 
                 await mod_log.send(
                     embed=embed_quarantine(interaction.user, target, message_counter)


### PR DESCRIPTION
## Problem

`src/bot/cogs/moderation/admin_quarantine.py` uses `time.sleep(0.2)` inside an `async` function to avoid rate limits during bulk message deletion. This blocks the entire bot event loop, making it appear offline or miss incoming events.

**Closes #136**

## Fix

Replace `time.sleep(0.2)` with `await asyncio.sleep(0.2)`:

```python
# Before — blocks event loop
import time
time.sleep(0.2)

# After — non-blocking
import asyncio
await asyncio.sleep(0.2)
```

## Impact

- Bot event loop remains responsive during bulk message deletion
- Other commands and events continue to be processed
- Rate limiting behavior preserved