### PR TITLE
Fix database health check endpoint

### DIFF
--- a/src/bot/core/api_helper.py
+++ b/src/bot/core/api_helper.py
@@ -35,7 +35,7 @@ class API:
             results = {}
             async with session.get(f"{self.api}/hc_api") as response:
                 results["api_status"] = await response.json()
-            async with session.get(f"{self.api}/hc_api") as response:
+            async with session.get(f"{self.api}/hc_db") as response:
                 results["db_status"] = await response.json()
             return results
 

--- a/tests/test_api_helper.py
+++ b/tests/test_api_helper.py
@@ -65,7 +65,9 @@ class HealthCheckTests(unittest.TestCase):
         results = asyncio.run(api.health_check())
 
         self.assertEqual(len(sessions), 1)
-        self.assertEqual(sessions[0].calls, ["http://eos.test/hc_api", "http://eos.test/hc_db"])
+        self.assertEqual(
+            sessions[0].calls, ["http://eos.test/hc_api", "http://eos.test/hc_db"]
+        )
         self.assertEqual(results["api_status"], {"url": "http://eos.test/hc_api"})
         self.assertEqual(results["db_status"], {"url": "http://eos.test/hc_db"})
 

--- a/tests/test_api_helper.py
+++ b/tests/test_api_helper.py
@@ -4,7 +4,6 @@ import types
 import unittest
 from pathlib import Path
 
-
 ROOT = Path(__file__).resolve().parents[1]
 BOT_SRC = ROOT / "src" / "bot"
 sys.path.insert(0, str(BOT_SRC))
@@ -33,9 +32,8 @@ class FakeResponse:
 
 
 class FakeSession:
-    calls = []
-
     def __init__(self, *args, **kwargs):
+        self.calls = []
         self.timeout = kwargs.get("timeout")
 
     async def __aenter__(self):
@@ -51,8 +49,14 @@ class FakeSession:
 
 class HealthCheckTests(unittest.TestCase):
     def test_health_check_calls_api_and_database_endpoints(self):
-        FakeSession.calls = []
-        api_helper.aiohttp.ClientSession = FakeSession
+        sessions = []
+
+        def make_session(*args, **kwargs):
+            session = FakeSession(*args, **kwargs)
+            sessions.append(session)
+            return session
+
+        api_helper.aiohttp.ClientSession = make_session
         api_helper.aiohttp.ClientTimeout = lambda total: total
 
         api = api_helper.API()
@@ -60,10 +64,8 @@ class HealthCheckTests(unittest.TestCase):
 
         results = asyncio.run(api.health_check())
 
-        self.assertEqual(
-            FakeSession.calls,
-            ["http://eos.test/hc_api", "http://eos.test/hc_db"],
-        )
+        self.assertEqual(len(sessions), 1)
+        self.assertEqual(sessions[0].calls, ["http://eos.test/hc_api", "http://eos.test/hc_db"])
         self.assertEqual(results["api_status"], {"url": "http://eos.test/hc_api"})
         self.assertEqual(results["db_status"], {"url": "http://eos.test/hc_db"})
 

--- a/tests/test_api_helper.py
+++ b/tests/test_api_helper.py
@@ -1,0 +1,72 @@
+import asyncio
+import sys
+import types
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+BOT_SRC = ROOT / "src" / "bot"
+sys.path.insert(0, str(BOT_SRC))
+
+sys.modules.setdefault(
+    "aiohttp",
+    types.SimpleNamespace(ClientSession=None, ClientTimeout=lambda total: total),
+)
+sys.modules.setdefault("requests", types.SimpleNamespace())
+
+from core import api_helper  # noqa: E402
+
+
+class FakeResponse:
+    def __init__(self, url):
+        self.url = url
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, traceback):
+        return False
+
+    async def json(self):
+        return {"url": self.url}
+
+
+class FakeSession:
+    calls = []
+
+    def __init__(self, *args, **kwargs):
+        self.timeout = kwargs.get("timeout")
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, traceback):
+        return False
+
+    def get(self, url):
+        self.calls.append(url)
+        return FakeResponse(url)
+
+
+class HealthCheckTests(unittest.TestCase):
+    def test_health_check_calls_api_and_database_endpoints(self):
+        FakeSession.calls = []
+        api_helper.aiohttp.ClientSession = FakeSession
+        api_helper.aiohttp.ClientTimeout = lambda total: total
+
+        api = api_helper.API()
+        api.api = "http://eos.test"
+
+        results = asyncio.run(api.health_check())
+
+        self.assertEqual(
+            FakeSession.calls,
+            ["http://eos.test/hc_api", "http://eos.test/hc_db"],
+        )
+        self.assertEqual(results["api_status"], {"url": "http://eos.test/hc_api"})
+        self.assertEqual(results["db_status"], {"url": "http://eos.test/hc_db"})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Summary:
- Updates the bot health_check helper to call /hc_db for the database status instead of calling /hc_api twice.
- Adds a focused unittest that verifies the helper requests /hc_api and /hc_db in order.
- Corrects the issue where the >hc command could report API health for both API and DB fields.

Validation:
- python -m unittest tests.test_api_helper -v
- Result: 1 test passed
- python -m unittest discover -s tests -v
- Result: 1 test passed
- python -m compileall -q src\bot\core\api_helper.py tests\test_api_helper.py
- Result: passed
- python -m ruff check src\bot\core\api_helper.py tests\test_api_helper.py
- Result: not run locally because ruff is not installed in this environment

Related issue:
- Closes #135

Risk:
- Low
- The change only updates the database health endpoint URL and adds isolated test coverage.