### PR TITLE
Fix API route JSON status codes

### DIFF
--- a/src/api/routes/healthchecks.py
+++ b/src/api/routes/healthchecks.py
@@ -16,9 +16,9 @@ def api_health_check():
     A simple healthcheck that returns an up status.
     """
     if request.method == "GET":
-        return jsonify({"status": "ok"}, 200)
+        return jsonify({"status": "ok"}), 200
 
-    return jsonify({"message": "improper request method"}, 405)
+    return jsonify({"message": "improper request method"}), 405
 
 
 @health_checks.route("/hc_db", methods=["GET"])
@@ -29,9 +29,9 @@ def database_health_check():
     if request.method == "GET":
         try:
             hc = eos.db.database_health_check()
-            return jsonify(hc, 200)
+            return jsonify(hc), 200
 
         except TypeError:
-            return jsonify({"status": "unhealthy", "error": "DB unreachable"}, 404)
+            return jsonify({"status": "unhealthy", "error": "DB unreachable"}), 404
 
-    return jsonify({"message": "improper request method"}, 404)
+    return jsonify({"message": "improper request method"}), 404

--- a/src/api/routes/logging.py
+++ b/src/api/routes/logging.py
@@ -25,7 +25,7 @@ def get_log_setting(log_id=None):
         # Retrieve a single setting
         result = eos.db.get_log_setting(log_id)
 
-    return jsonify(result, 200)
+    return jsonify(result), 200
 
 
 # @settings.route('/log_settings', methods=['GET'])
@@ -37,7 +37,7 @@ def get_log_setting(log_id=None):
 #     """
 #     result = eos.db.get_log_settings()
 #
-#     return jsonify(result, 200)
+#     return jsonify(result), 200
 
 
 @logs.route("/logging/<log_id>", methods=["PUT"])
@@ -48,9 +48,9 @@ def update_log_setting(log_id):
     if request.method == "PUT":
         data = request.json
         result = eos.db.update_logging(int(log_id), data["value"])
-        return jsonify(result, 200)
+        return jsonify(result), 200
 
-    return jsonify({"message": "improper request method"}, 405)
+    return jsonify({"message": "improper request method"}), 405
 
 
 @logs.route("/logging", methods=["POST"])
@@ -61,9 +61,9 @@ def add_log_setting():
     if request.method == "POST":
         data = request.json
         result = eos.db.add_log_setting(data["name"], data["value"])
-        return jsonify(result, 201)
+        return jsonify(result), 201
 
-    return jsonify({"message": "improper request method"}, 405)
+    return jsonify({"message": "improper request method"}), 405
 
 
 @logs.route("/logging/<int:log_id>", methods=["DELETE"])
@@ -73,6 +73,6 @@ def delete_log_setting(log_id):
     """
     if request.method == "DELETE":
         result = eos.db.delete_log_setting(log_id)
-        return jsonify(result, 200)
+        return jsonify(result), 200
 
-    return jsonify({"message": "improper request method"}, 405)
+    return jsonify({"message": "improper request method"}), 405

--- a/src/api/routes/roles.py
+++ b/src/api/routes/roles.py
@@ -25,7 +25,7 @@ def get_role(role_id=None):
         # Retrieve a single role
         result = eos.db.get_role(role_id)
 
-    return jsonify(result, 200)
+    return jsonify(result), 200
 
 
 @role.route("/role/<role_id>", methods=["PUT"])
@@ -36,9 +36,9 @@ def update_role(role_id):
     if request.method == "PUT":
         data = request.json
         result = eos.db.update_role(int(role_id), data["value"])
-        return jsonify(result, 200)
+        return jsonify(result), 200
 
-    return jsonify({"message": "improper request method"}, 405)
+    return jsonify({"message": "improper request method"}), 405
 
 
 @role.route("/role", methods=["POST"])
@@ -49,9 +49,9 @@ def add_role():
     if request.method == "POST":
         data = request.json
         result = eos.db.add_role(data["name"], data["value"])
-        return jsonify(result, 201)
+        return jsonify(result), 201
 
-    return jsonify({"message": "improper request method"}, 405)
+    return jsonify({"message": "improper request method"}), 405
 
 
 @role.route("/role/<int:role_id>", methods=["DELETE"])
@@ -61,6 +61,6 @@ def delete_role(role_id):
     """
     if request.method == "DELETE":
         result = eos.db.delete_role(role_id)
-        return jsonify(result, 200)
+        return jsonify(result), 200
 
-    return jsonify({"message": "improper request method"}, 405)
+    return jsonify({"message": "improper request method"}), 405

--- a/src/api/routes/settings.py
+++ b/src/api/routes/settings.py
@@ -25,7 +25,7 @@ def get_setting(setting_id):
         # Retrieve a single setting
         result = eos.db.get_setting(setting_id)
 
-    return jsonify(result, 200)
+    return jsonify(result), 200
 
 
 @settings.route("/settings/<setting_id>", methods=["PUT"])
@@ -36,9 +36,9 @@ def update_setting(setting_id):
     if request.method == "PUT":
         data = request.json
         result = eos.db.update_setting(int(setting_id), data["value"])
-        return jsonify(result, 200)
+        return jsonify(result), 200
 
-    return jsonify({"message": "improper request method"}, 405)
+    return jsonify({"message": "improper request method"}), 405
 
 
 @settings.route("/settings", methods=["POST"])
@@ -49,9 +49,9 @@ def add_setting():
     if request.method == "POST":
         data = request.json
         result = eos.db.add_setting(data["name"], data["value"])
-        return jsonify(result, 201)
+        return jsonify(result), 201
 
-    return jsonify({"message": "improper request method"}, 405)
+    return jsonify({"message": "improper request method"}), 405
 
 
 @settings.route("/settings/<int:setting_id>", methods=["DELETE"])
@@ -61,6 +61,6 @@ def delete_setting(setting_id):
     """
     if request.method == "DELETE":
         result = eos.db.delete_setting(setting_id)
-        return jsonify(result, 200)
+        return jsonify(result), 200
 
-    return jsonify({"message": "improper request method"}, 405)
+    return jsonify({"message": "improper request method"}), 405

--- a/src/api/tests/test_route_status_codes.py
+++ b/src/api/tests/test_route_status_codes.py
@@ -1,0 +1,123 @@
+import unittest
+
+from flask import Flask
+from routes.healthchecks import health_checks
+from routes.logging import logs
+from routes.roles import role
+from routes.settings import settings
+
+
+class FakeDB:
+    def __init__(self):
+        self.db_unreachable = False
+
+    def get_roles(self):
+        return {"resource": "roles"}
+
+    def update_role(self, role_id, value):
+        return {"id": role_id, "value": value}
+
+    def add_role(self, name, value):
+        return {"name": name, "value": value}
+
+    def delete_role(self, role_id):
+        return {"deleted": role_id}
+
+    def get_log_settings(self):
+        return {"resource": "logging"}
+
+    def update_logging(self, log_id, value):
+        return {"id": log_id, "value": value}
+
+    def add_log_setting(self, name, value):
+        return {"name": name, "value": value}
+
+    def delete_log_setting(self, log_id):
+        return {"deleted": log_id}
+
+    def get_settings(self):
+        return {"resource": "settings"}
+
+    def get_setting(self, setting_id):
+        return {"id": setting_id}
+
+    def update_setting(self, setting_id, value):
+        return {"id": setting_id, "value": value}
+
+    def add_setting(self, name, value):
+        return {"name": name, "value": value}
+
+    def delete_setting(self, setting_id):
+        return {"deleted": setting_id}
+
+    def database_health_check(self):
+        if self.db_unreachable:
+            raise TypeError("DB unreachable")
+
+        return {"status": "healthy"}
+
+
+def create_app():
+    app = Flask(__name__)
+    app.db = FakeDB()
+    app.register_blueprint(health_checks)
+    app.register_blueprint(logs)
+    app.register_blueprint(settings)
+    app.register_blueprint(role)
+    return app
+
+
+class RouteStatusCodeTest(unittest.TestCase):
+    def setUp(self):
+        self.app = create_app()
+        self.client = self.app.test_client()
+
+    def assert_object_response(self, method, path, expected_status, json=None):
+        response = getattr(self.client, method)(path, json=json)
+
+        self.assertEqual(response.status_code, expected_status)
+        self.assertIsInstance(response.get_json(), dict)
+
+    def test_roles_routes_return_status_codes_outside_json_body(self):
+        self.assert_object_response("get", "/role", 200)
+        self.assert_object_response("put", "/role/1", 200, json={"value": "admin"})
+        self.assert_object_response(
+            "post",
+            "/role",
+            201,
+            json={"name": "moderator", "value": "mod"},
+        )
+        self.assert_object_response("delete", "/role/1", 200)
+
+    def test_logging_routes_return_status_codes_outside_json_body(self):
+        self.assert_object_response("get", "/logging", 200)
+        self.assert_object_response("put", "/logging/1", 200, json={"value": "on"})
+        self.assert_object_response(
+            "post",
+            "/logging",
+            201,
+            json={"name": "joins", "value": "enabled"},
+        )
+        self.assert_object_response("delete", "/logging/1", 200)
+
+    def test_settings_routes_return_status_codes_outside_json_body(self):
+        self.assert_object_response("get", "/settings/0", 200)
+        self.assert_object_response("put", "/settings/1", 200, json={"value": "on"})
+        self.assert_object_response(
+            "post",
+            "/settings",
+            201,
+            json={"name": "prefix", "value": ">"},
+        )
+        self.assert_object_response("delete", "/settings/1", 200)
+
+    def test_healthcheck_routes_return_status_codes_outside_json_body(self):
+        self.assert_object_response("get", "/hc_api", 200)
+        self.assert_object_response("get", "/hc_db", 200)
+
+        self.app.db.db_unreachable = True
+        self.assert_object_response("get", "/hc_db", 404)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Description of your PR

Closes #134.

This fixes the affected Flask API routes so they return status codes as `(jsonify(payload), status_code)` response tuples instead of embedding the status code inside the JSON body, which produced array-like responses such as `[{...}, 200]`.

## Describe your changes

### Fixed

- Updated the roles, logging, settings, and healthcheck routes to return JSON object bodies with the intended HTTP status codes.
- Kept the existing response payload shapes and route behavior while correcting status-code handling.

### Added

- Added route-level unittest coverage for roles, logging, settings, and healthcheck responses.
- Covered both the returned HTTP status codes and the JSON object response bodies.

### Validation

- `uv run --package eos-api python -m unittest discover -s tests -v` from `src/api`
- `uv run --dev ruff check src/api/routes/roles.py src/api/routes/logging.py src/api/routes/settings.py src/api/routes/healthchecks.py src/api/tests/test_route_status_codes.py`
- `uv run --dev ruff format --check src/api/routes/roles.py src/api/routes/logging.py src/api/routes/settings.py src/api/routes/healthchecks.py src/api/tests/test_route_status_codes.py`
- `uv run --package eos-api python -m compileall -q src/api/routes/roles.py src/api/routes/logging.py src/api/routes/settings.py src/api/routes/healthchecks.py src/api/tests/test_route_status_codes.py`
- `uv run --dev pre-commit run --files src/api/routes/roles.py src/api/routes/logging.py src/api/routes/settings.py src/api/routes/healthchecks.py src/api/tests/test_route_status_codes.py`

## Issue link

Closes #134.

## Checklist

- [x] Does an issue of this PR exist and have you linked it?
- [x] Have your ran `pre-commit` over your PR?
- [x] Was this PR branched off from `master`?
- [x] Is this PR merging to `master`?