### PR TITLE
Preventing people from farming points by adding the bot to a private server.

### DIFF
--- a/src/bot/cogs/admin/points.py
+++ b/src/bot/cogs/admin/points.py
@@ -1,5 +1,6 @@
 import datetime
 import logging
+import os
 
 import discord
 from discord.ext import commands
@@ -201,6 +202,9 @@ class Points(commands.Cog):
         """
         if message.author.bot:
             return
+        if message.guild.id != int(os.getenv("MASTER_GUILD")):
+            return
+
         msg = message.content.split()
         logger.debug(
             f"Updating {len(msg)} points for {message.author.display_name} for sending a message."


### PR DESCRIPTION
## Description of your PR
This PR adds a check for Guild in `on_message` Cog listener to only add points if the message is sent in the Master Guild.

## Describe your changes
Same as above. Actually, there should be separate tables in DB for every server the bot is in to prevent this but right now there is a lot of refactoring going on so just a dirty fix for now.

### Added
None.

### Fixed
Same as above.

### Changed
None.

### Removed
None.

## Issue link
None.

## Checklist

- [ ] Does an issue of this PR exist and have you linked it?
- [X] Have your ran `pre-commit` over your PR?
- [X] Was this PR branched off from `master`?
- [X] Is this PR merging to `master`?
