### PR TITLE
Bugfix/db silent bugs

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ What it does:
 
 ## Configuration
 
-If you already have postgres installed on your system then you may have conflicting ports, in that case change the `POSTGRES_PORT` to a free port in the `.env`, usually `5433`. Then rebuild by using following command:
+If you already have postgres installed on your system then you may have conflicting ports, in that case change
+the `POSTGRES_PORT_HOST` to a free port in the `.env`, usually `5433`. (Clarification:`POSTGRES_PORT` env variable is only used within the container environment). Then rebuild by using following command:
 ```
 docker compose up -d --build
 ```

--- a/src/.env.EXAMPLE
+++ b/src/.env.EXAMPLE
@@ -18,7 +18,8 @@ STREAM_LOGS=True
 
 # Database — don't change unless you know what you're doing
 POSTGRES_HOST=postgres
-POSTGRES_PORT=5432
+POSTGRES_PORT=5432 # used in container
+POSTGRES_PORT_HOST=5432 # host system only
 PGUSER=postgres
 # POSTGRES_USER must match PGUSER — the postgres image uses this to create the superuser
 POSTGRES_USER=postgres

--- a/src/.env.EXAMPLE
+++ b/src/.env.EXAMPLE
@@ -18,8 +18,8 @@ STREAM_LOGS=True
 
 # Database — don't change unless you know what you're doing
 POSTGRES_HOST=postgres
-POSTGRES_PORT=5432 # used in container
-POSTGRES_PORT_HOST=5432 # host system only
+POSTGRES_PORT=5432
+POSTGRES_PORT_HOST=5432
 PGUSER=postgres
 # POSTGRES_USER must match PGUSER — the postgres image uses this to create the superuser
 POSTGRES_USER=postgres

--- a/src/db/init.sql
+++ b/src/db/init.sql
@@ -1,10 +1,3 @@
-DO $$
-BEGIN
-    IF NOT EXISTS (SELECT FROM pg_database WHERE datname = 'eos') THEN
-        CREATE DATABASE eos;
-    END IF;
-END $$;
-
 -- Create serversettings table
 CREATE TABLE IF NOT EXISTS serversettings (
     id SERIAL PRIMARY KEY,

--- a/src/db/migration-entrypoint.sh
+++ b/src/db/migration-entrypoint.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-until pg_isready -h "$POSTGRES_HOST" -U "$POSTGRES_USER" -d "$POSTGRES_DATABASE"; do
+until pg_isready -h "$POSTGRES_HOST" -U "$POSTGRES_USER" -d "$POSTGRES_DB"; do
     sleep 1
 done
 

--- a/src/docker-compose.yml
+++ b/src/docker-compose.yml
@@ -60,7 +60,7 @@ services:
       retries: 5
       start_period: 20s
     ports:
-      - "127.0.0.1:${POSTGRES_PORT}:5432"
+      - "127.0.0.1:${POSTGRES_PORT_HOST}:${POSTGRES_PORT}"
     networks:
       - eos
     restart: unless-stopped

--- a/src/docker-compose.yml
+++ b/src/docker-compose.yml
@@ -60,7 +60,7 @@ services:
       retries: 5
       start_period: 20s
     ports:
-      - "127.0.0.1:${POSTGRES_PORT_HOST}:${POSTGRES_PORT}"
+      - "127.0.0.1:${POSTGRES_PORT_HOST:-5432}:${POSTGRES_PORT}"
     networks:
       - eos
     restart: unless-stopped


### PR DESCRIPTION
## Description of your PR
Some fixes to small bugs in the docker workflow that only come up when changing the psql database name/other settings

## Describe your changes

### Fixed
- fix a misnamed envvar that is swallowed silently if using the default psql username
- remove a needless block in .sql file that can never do anything anyway; docker creates the database based on .env settings. This block fails silently when using default "eos" names but errors when changing name
- POSTGRES_PORT is kind of confusingly used because in .yml file the psql container port is hardcoded anyway

## Issue link
Closes #165 

## Checklist
- [X] Does an issue of this PR exist and have you linked it?
- [X] Have your ran `pre-commit` over your PR?
- [X] Was this PR branched off from `master`?
- [X] Is this PR merging to `master`?
