### PR TITLE
[FIX]: Change from type tuple to list

### DIFF
--- a/src/bot/cogs/constants.py
+++ b/src/bot/cogs/constants.py
@@ -1,6 +1,6 @@
 from discord.app_commands import Choice
 
-WEBPAGE_CHOICES: tuple[Choice[str], ...] = (
+WEBPAGE_CHOICES: list[Choice[str], ...] = [
     Choice(name="Home", value=""),
     Choice(name="Getting started", value="getting-started/"),
     Choice(name="Resources", value="resources/"),
@@ -9,7 +9,7 @@ WEBPAGE_CHOICES: tuple[Choice[str], ...] = (
     Choice(name="Code Adventure", value="code-adventure/"),
     Choice(name="Learning path", value="resources/learning-path/"),
     Choice(name="Codeblocks", value="rules/channels/#__tabbed_2_1"),
-)
+]
 
 LATEX_COLORS = {
     "emerald": "Emerald",


### PR DESCRIPTION
to fix `TypeError` that emerged from commit 1c51d32.

# Changed
`constants.py` modified: `WEBPAGE_CHOICES` now type `list` instead of `tuple`.

## Checklist
<!-- Put X inside the square brackets to check them. -->

- [ ] Does an issue for this PR exist, and have you linked it?
- [x] Have you ran `pre-commit` over your PR?
- [x] Was this PR branched off from `master`?
- [x] Is this PR merging to `master`?
