### PR TITLE
LaTeX command mentions the user who called it

### DIFF
--- a/src/bot/cogs/features/_latex_utilities.py
+++ b/src/bot/cogs/features/_latex_utilities.py
@@ -126,7 +126,13 @@ class LatexView(discord.ui.View):
             )
             return
 
-        await interaction.followup.send(embed=embed)
+        channel = interaction.channel
+
+        if isinstance(channel, (discord.TextChannel, discord.Thread)):
+            await channel.send(
+                content=interaction.user.mention,
+                embed=embed,
+            )
 
         for child in self.children:
             if isinstance(child, discord.ui.Button):


### PR DESCRIPTION
Instead of having an embed which replies to its original ephemeral embed (causing an ugly "original message was deleted" reply on all public embeds) it now sends a standalone embed, unrelated to interaction. Additionally, the user who initiated the command is mentioned so we know who sent it.

## Description of your PR

## Describe your changes
Instead of `interaction.followup.send()`, `interaction.channel.send()` is used to create a stand-alone embed message which does not reply to anything. Additionally, the user who initiated the command is mentioned with `content=interaction.user.mention`

### Changed
a small section of publish() in _latex_utilities.py

## Checklist
<!-- Put X inside the square brackets to check them. -->

- [X] Have your ran `pre-commit` over your PR?
- [X] Was this PR branched off from `master`?
- [X] Is this PR merging to `master`?
